### PR TITLE
Fixing ES5 - Strict Mode Test

### DIFF
--- a/test/es5/strictmode.js
+++ b/test/es5/strictmode.js
@@ -19,4 +19,4 @@ Check if browser implements ECMAScript 5 Object strict mode.
 
 */
 
-  Modernizr.addTest('strictmode', (function(){ "use strict"; 
+  Modernizr.addTest('strictmode', (function(){ "use strict";}));


### PR DESCRIPTION
Not sure, but there seems to be missing a couple of missing characters at the end. Browserify won't compile it, obviously. 
