### PR TITLE
Add link to repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.2",
   "description": "Modernizr wrapper for use with browserify",
   "main": "index.js",
-  "repository": "",
+  "repository": "https://github.com/jnordberg/browsernizr",
   "keywords": [
     "modernizr",
     "modernizer",


### PR DESCRIPTION
This makes `npm repo browsernizr` work. Otherwise, it will throw up

```
npm ERR! Error: no repository
npm ERR!     at getUrlAndOpen (/usr/local/lib/node_modules/npm/lib/repo.js:39:21)
npm ERR!     at /usr/local/lib/node_modules/npm/lib/repo.js:58:5
npm ERR!     at saved (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:167:7)
npm ERR!     at Object.oncomplete (fs.js:107:15)
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! System Darwin 13.2.0
npm ERR! command "node" "/usr/local/bin/npm" "repo" "browsernizr"
npm ERR! cwd /Users/luwei/workspace/hive/hive-js
npm ERR! node -v v0.10.28
npm ERR! npm -v 1.4.20
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/luwei/workspace/hive/hive-js/npm-debug.log
npm ERR! not ok code 0
```
