### PR TITLE
Fix relative module paths

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -16,7 +16,11 @@ unAMD = (src, reqPath='./') ->
     req = ''
     for i in [0...modules.length]
       req += "var #{ names[i] } = " if names[i]?.length > 0
-      req += "require('#{ reqPath }#{ modules[i] }');\n"
+      if modules[i].match /^test\//
+        modulePath = reqPath.replace /lib\//, '' + modules[i]
+      else
+        modulePath = reqPath + modules[i]
+      req += "require('#{ modulePath }');\n"
     src = "#{ req }\n#{ src }\n"
   if exports?
     src += "\nmodule.exports = #{ exports[1] };"


### PR DESCRIPTION
The most recent version of Modernizr (3.0.0-alpha.4) includes relative paths like ['test/css/supports'](https://github.com/Modernizr/Modernizr/blob/master/feature-detects/css/transforms3d.js#L12) which breaks browsernizr, creating require paths like `./../lib/test/css/supports`

This may not be the most elegant way of fixing things, but it works.

I'm not including the new build here, in order to keep the pull request clean