### PR TITLE
support usage in dependent packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,12 +10,15 @@ testRunner();
 // Remove the "no-js" class if it exists
 setClasses(classes);
 
-delete ModernizrProto.addTest;
-delete ModernizrProto.addAsyncTest;
-
 // Run the things that are supposed to run after the tests
 for (var i = 0; i < Modernizr._q.length; i++) {
   Modernizr._q[i]();
 }
 
-module.exports = Modernizr;
+module.exports = Object.keys(Modernizr).reduce(function (modernizr, key) {
+    modernizr.key = Modernizr[key];
+
+    delete Modernizr[key];
+
+    return modernizr;
+}, {});

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ for (var i = 0; i < Modernizr._q.length; i++) {
 }
 
 module.exports = Object.keys(Modernizr).reduce(function (modernizr, key) {
-    modernizr.key = Modernizr[key];
+    modernizr[key] = Modernizr[key];
 
     delete Modernizr[key];
 


### PR DESCRIPTION
I discovered that browsernizr cannot be used in two or more npm packages which depend on each other. 

I made a few modifications which make that possible. Instead of removing `addTest()` and `addAsyncTest()` before returning it, I modified the code to only return a newly created object with the test results instead. In addition to that the test results are removed from the internal `Modernizr` instance so it can be used again as if it had never been used before.